### PR TITLE
The POC of Runtime Input Validation for PySpark

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches:
+    - '**'
+
+jobs:
+  build:
+    name: "Python Test ${{ matrix.python-version }}:"
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version:
+          - 3.6
+          - 3.7
+          - 3.8
+          - 3.9
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Run python test
+        run: |
+          python -m unittest

--- a/type_checker.py
+++ b/type_checker.py
@@ -1,26 +1,26 @@
-from __future__ import annotations
-
 import inspect
 import functools
+import typing
 
 
 # We could also add `allow_list` to allow user enable the checkers on specific args
 # type checker on every input args (except arg in block_list)
 # Will raise TypeError when args type is unmatched.
-def type_checker(block_list=['self']):
+def type_checker(block_list=['return']):
     def decorator(func):
         @functools.wraps(func)
         def wrapper(self, *args, **kw):
             # Get all input args name and value
             # like: OrderedDict([('self', <Demo...>), ('a', 1), ('b', 2)])
-            func_args = inspect.signature(func).bind(self, *args, **kw).arguments
-            for k, v in func_args.items():
+            kv = inspect.signature(func).bind(self, *args, **kw).arguments
+            hints = typing.get_type_hints(func)
+            for k, t in hints.items():
                 if block_list and k in block_list:
                     # skip `self` type check
                     continue
                 # Get annotation type from annotaions, __annotations__ like:
                 # {'a': <class 'int'>, 'b': <class 'int'>, 'return': <class 'int'>}
-                t = func.__annotations__.get(k)
+                v = kv.get(k)
                 # Raise the TypeError when input value is not match with type
                 if not isinstance(v, t):
                     raise TypeError("The type of %s should be a %s type" % (k, t))


### PR DESCRIPTION
# Backgroud
This idea coming from [SPARK-35176](https://issues.apache.org/jira/browse/SPARK-35176). There are so many not very elegant input validation on PySpark, like [this](https://github.com/apache/spark/blob/355c39939d9e4c87ffc9538eb822a41cb2ff93fb/python/pyspark/sql/dataframe.py#L1137) and [this](https://github.com/apache/spark/blob/355c39939d9e4c87ffc9538eb822a41cb2ff93fb/python/pyspark/sql/dataframe.py#L1228):
- Wrong exception type
- Mixup error message
- Redundant validation code in everywhere
- Lack input validation in some important interface.

Here is the simple POC of input validation based on annotations, core implementation is a `@type_checker` decractor to do type check on function value types, the TypeError will be raised when failed to check type.

# Implementation
Code: https://github.com/Yikun/annotation-type-checker/blob/main/type_checker.py
Test: https://github.com/Yikun/annotation-type-checker/blob/main/test_type_checker.py
CI is runing as below, [code in here](https://github.com/Yikun/annotation-type-checker/blob/99aac62795bd93e86c57ba6c9356d8670ff55df6/.github/workflows/python-test.yml)

Quick Note:
1. Raise the TypeError when specific input is not match:
https://github.com/Yikun/annotation-type-checker/blob/c97158bab04afb3fd10f37a73fd9d37b22e135c8/type_checker.py#L25-L26

~2. Python version should be > 3.7~
~This PR is a test CI for type checker in different python version. You can see Python3.6 failed, because the `__annotations__` feature is enabled after python 3.7, see more in [PEP-0526](https://www.python.org/dev/peps/pep-0526/#runtime-effects-of-type-annotations)~

2.  Use the `typing.get_type_hints` to get input hint type of func.

# Example
1. If you want to use it:
  ~- Python >= 3.7.~
  - the fucntion should add annotation on function for input value.
  - the fucntion should decorated by `@type_checker`.
You can see demo in:
https://github.com/Yikun/annotation-type-checker/blob/c97158bab04afb3fd10f37a73fd9d37b22e135c8/test_type_checker.py#L10-L20

# Random thoughts
1. **Where is the final stage?**
- This is expected to merged into pyspark in some time, yep, rather than a dependency.
- it is **NOT** be considered enable for **ALL** pyspark function, the first step is only for cleanup type error in some function, that means no user-facing changed.

2. **Why not stub file** ? I also considered using stub file as runtime type check rule, but [PEP-0484](https://www.python.org/dev/peps/pep-0484/#stub-files) said: 
> Stub files are files containing type hints that are only for use by the type checker, **not at runtime**.

3. **What's the benefiit for PySpark?**
The idea coming from [SPARK-35176](https://issues.apache.org/jira/browse/SPARK-35176), I saw so many wrong exception type raised with mixed exception message, we can cleanup them.
- Cleanup like [this](https://github.com/apache/spark/blob/355c39939d9e4c87ffc9538eb822a41cb2ff93fb/python/pyspark/sql/dataframe.py#L1137) and [this](https://github.com/apache/spark/blob/355c39939d9e4c87ffc9538eb822a41cb2ff93fb/python/pyspark/sql/dataframe.py#L1228) style redundant code, using `annotation` + `@type_checker`
- Make type error exception message standardized.
- Maybe could be the subtask as [SPARK-32082: Project Zen: Improving Python usability](https://issues.apache.org/jira/projects/SPARK/issues/SPARK-32082)

# Nest step
After get some info from pyspark develeper as initial idea, if no objection will send it to ML, then integrate it into PySpark.